### PR TITLE
Navigation fix

### DIFF
--- a/MovieShowcase/Common/CarouselView.swift
+++ b/MovieShowcase/Common/CarouselView.swift
@@ -35,17 +35,22 @@ struct CarouselView: View {
             HStack {
                 ForEach(0..<movies.count, id: \.self) { index in
                     let movie = movies[index]
-                    Image(movie.imageUrl)
-                        .resizable()
-                        .scaledToFill()
-                        .frame(height: 170)
-                        .background(.red)
-                        .clipShape(RoundedRectangle(cornerRadius: 8.0))
-                        .padding(.horizontal, 2)
-                        .onTapGesture {
-                            itemTapped(index, movie)
-                        }
+                    
+                    NavigationLink {
+                        LikedView(movie: movie)
+                    } label: {
+                        Image(movie.imageUrl)
+                            .resizable()
+                            .scaledToFill()
+                            .frame(height: 170)
+                            .background(.red)
+                            .clipShape(RoundedRectangle(cornerRadius: 8.0))
+                            .padding(.horizontal, 2)
+                    }
                 }
+            }
+            .navigationDestination(for: Movie.self) { movie in
+                LikedView(movie: movie) // Navigate to movie detail
             }
         }
     }

--- a/MovieShowcase/Common/CarouselView.swift
+++ b/MovieShowcase/Common/CarouselView.swift
@@ -39,18 +39,19 @@ struct CarouselView: View {
                     NavigationLink {
                         LikedView(movie: movie)
                     } label: {
-                        Image(movie.imageUrl)
-                            .resizable()
-                            .scaledToFill()
-                            .frame(height: 170)
-                            .background(.red)
-                            .clipShape(RoundedRectangle(cornerRadius: 8.0))
-                            .padding(.horizontal, 2)
+                        VStack {
+                            Image(movie.imageUrl)
+                                .resizable()
+                                .scaledToFill()
+                                .frame(height: 170)
+                                .background(.red)
+                                .clipShape(RoundedRectangle(cornerRadius: 8.0))
+                                .padding(.horizontal, 2)
+                            Text(movie.title)
+                                
+                        }
                     }
                 }
-            }
-            .navigationDestination(for: Movie.self) { movie in
-                LikedView(movie: movie) // Navigate to movie detail
             }
         }
     }

--- a/MovieShowcase/TabView/LandingTabView.swift
+++ b/MovieShowcase/TabView/LandingTabView.swift
@@ -9,35 +9,31 @@ import SwiftUI
 
 struct LandingTabView: View {
     var body: some View {
-        
         TabView {
-            NavigationStack {
-                HomeView()
-                    .tabItem {
-                        Image(systemName: "house")
-                        Text("Home")
-                    }.tag(1)
-                
-                LikedView()
-                    .tabItem {
-                        Image(systemName: "hand.thumbsup.fill")
-                        Text("Liked")
-                    }.tag(2)
-                
-                MoviesView()
-                    .tabItem {
-                        Image(systemName: "movieclapper.fill")
-                        Text("Movies")
-                    }.tag(3)
-                
-                SeriesView()
-                    .tabItem {
-                        Image(systemName: "movieclapper.fill")
-                        Text("Series")
-                    }.tag(4)
-            }
+            HomeView()
+                .tabItem {
+                    Image(systemName: "house")
+                    Text("Home")
+                }.tag(1)
+            
+            LikedView(movie: Movie(title: "", imageUrl: ""))
+                .tabItem {
+                    Image(systemName: "hand.thumbsup.fill")
+                    Text("Liked")
+                }.tag(2)
+            
+            MoviesView()
+                .tabItem {
+                    Image(systemName: "movieclapper.fill")
+                    Text("Movies")
+                }.tag(3)
+            
+            SeriesView()
+                .tabItem {
+                    Image(systemName: "movieclapper.fill")
+                    Text("Series")
+                }.tag(4)
         }
-        
     }
 }
 

--- a/MovieShowcase/Views/HomeView.swift
+++ b/MovieShowcase/Views/HomeView.swift
@@ -14,41 +14,26 @@ struct HomeView: View {
     @State private var selectedMovie: Movie? = nil
     
     var body: some View {
-        ScrollView {
-            if let img = movies.randomElement()?.imageUrl {
-                BannerView(imageName:img, heightRatio: 0.6)
+        NavigationStack {
+            ScrollView {
+                if let img = movies.randomElement()?.imageUrl {
+                    BannerView(imageName:img, heightRatio: 0.6)
+                }
+                
+                CarouselView(movies: movies.shuffled(), headerTitle: "Trending", itemTapped: {index, movie in
+//                    selectedMovie = movie
+                })
+                
+                CarouselView(movies: movies.shuffled(), headerTitle: "Upcoming", itemTapped: {index, movie in
+//                    selectedMovie = movie
+                })
+                
+                CarouselView(movies: movies.shuffled(), headerTitle: "Movies", itemTapped: {index, movie in
+//                    selectedMovie = movie
+                })
             }
-            
-            CarouselView(movies: movies.shuffled(), headerTitle: "Trending", itemTapped: {index, movie in
-                selectedMovie = movie
-            })
-            
-            CarouselView(movies: movies.shuffled(), headerTitle: "Upcoming", itemTapped: {index, movie in
-                
-            })
-            
-            CarouselView(movies: movies.shuffled(), headerTitle: "Movies", itemTapped: {index, movie in
-                
-            })
-            //------------------Depricated code------------------------//
-            //NavigationLink(
-            //destination: LikedView(),
-            //tag: selectedMovie ?? Movie(title: "", imageUrl: ""),
-            //selection: $selectedMovie
-            //) {
-            //EmptyView() // The NavigationLink is invisible, activated by selectedItem
-            //}
-            
-            //------------------Undepricated code-----------------------//
-//            NavigationLink(value: selectedMovie) {
-//                EmptyView() // The NavigationLink is invisible, activated by selectedItem
-//            }
-//            .navigationDestination(for: Movie.self) { itemTitle in
-//                LikedView()
-//            }
-            
-        }
-        .ignoresSafeArea(edges: .top)
+            .ignoresSafeArea(edges: .top)
+        }        
     }
 }
 

--- a/MovieShowcase/Views/HomeView.swift
+++ b/MovieShowcase/Views/HomeView.swift
@@ -21,15 +21,15 @@ struct HomeView: View {
                 }
                 
                 CarouselView(movies: movies.shuffled(), headerTitle: "Trending", itemTapped: {index, movie in
-//                    selectedMovie = movie
+                    selectedMovie = movie
                 })
                 
                 CarouselView(movies: movies.shuffled(), headerTitle: "Upcoming", itemTapped: {index, movie in
-//                    selectedMovie = movie
+                    selectedMovie = movie
                 })
                 
                 CarouselView(movies: movies.shuffled(), headerTitle: "Movies", itemTapped: {index, movie in
-//                    selectedMovie = movie
+                    selectedMovie = movie
                 })
             }
             .ignoresSafeArea(edges: .top)

--- a/MovieShowcase/Views/LikedView.swift
+++ b/MovieShowcase/Views/LikedView.swift
@@ -25,21 +25,21 @@ struct LikedView: View {
         "popcorn.fill",
     ]
     
+    @State var movie: Movie
+    
     var body: some View {
         NavigationStack {
-            List(images, id: \.self) { name in
                 HStack {
-                    Text("Object Name")
+                    Text(movie.title)
                     Spacer()
-                    Image(systemName: name)
+                    Image(movie.imageUrl)
                 }
                 .padding()
-            }
         }
         .navigationTitle("Liked")
     }
 }
 
 #Preview {
-    LikedView()
+    LikedView(movie: Movie(title: "Title", imageUrl: "imgUrl"))
 }


### PR DESCRIPTION
Creating the navigation link in a right manner to navigate to movie detail view. 
Through this fix, we are able to solve the following issues.
1. Detail view poping back to previous view.
2. Detail view visible on the main tab view without the user tap of any image. 