### PR TITLE
Replace Horizontal scroll  implementation with LazyGridView 

### DIFF
--- a/MovieShowcase/Common/BannerView.swift
+++ b/MovieShowcase/Common/BannerView.swift
@@ -1,9 +1,3 @@
-//
-//  BannerView.swift
-//  MovieShowcase
-//
-//  Created by Pratik Parmar on 04/08/24.
-//
 
 import SwiftUI
 

--- a/MovieShowcase/Common/CarouselView.swift
+++ b/MovieShowcase/Common/CarouselView.swift
@@ -24,7 +24,7 @@ struct CarouselHeaderView: View {
     }
 }
 
-struct HorizontalGridView: View {
+struct CarouselView: View {
     var movies = (1...15).compactMap {
         Movie(title: "Title", imageUrl: "img\($0)")
     }
@@ -64,7 +64,7 @@ struct HorizontalGridView: View {
 }
 
 #Preview {
-    HorizontalGridView(movies: [Movie(title: "Title", imageUrl: "popcorn.fill"),
+    CarouselView(movies: [Movie(title: "Title", imageUrl: "popcorn.fill"),
                                 Movie(title: "Title", imageUrl: "popcorn.fill"),
                                 Movie(title: "Title", imageUrl: "popcorn.fill")], headerTitle: "Title")
 }

--- a/MovieShowcase/Common/CarouselView.swift
+++ b/MovieShowcase/Common/CarouselView.swift
@@ -1,14 +1,7 @@
-//
-//  CarouselView.swift
-//  MovieShowcase
-//
-//  Created by Pratik Parmar on 04/08/24.
-//
 
 import SwiftUI
 
 struct CarouselHeaderView: View {
-    
     @State var title: String
     var movies = (1...15).compactMap {
         Movie(title: "Title", imageUrl: "img\($0)")
@@ -24,55 +17,54 @@ struct CarouselHeaderView: View {
             })
             .navigationDestination(for: String.self) { str in
                 GridView(movies: movies)
-                .toolbar(.hidden, for: .tabBar)
-                    
+                    .toolbar(.hidden, for: .tabBar)
             }
         }
         .padding()
     }
 }
 
-struct CarouselView: View {
-    
-    @State var movies: [Movie]
+struct HorizontalGridView: View {
+    var movies = (1...15).compactMap {
+        Movie(title: "Title", imageUrl: "img\($0)")
+    }
     @State var headerTitle: String
-    var itemTapped: (Int, Movie) -> Void
+    let rows = [GridItem()]
     
     var body: some View {
         CarouselHeaderView(title: headerTitle)
         ScrollView(.horizontal) {
-            HStack {
+            LazyHGrid(rows: rows) {
                 ForEach(0..<movies.count, id: \.self) { index in
                     let movie = movies[index]
-                    
                     NavigationLink {
                         LikedView(movie: movie)
                             .toolbar(.hidden, for: .tabBar)
-
+                        
                     } label: {
                         VStack {
                             Image(movie.imageUrl)
                                 .resizable()
                                 .scaledToFill()
                                 .frame(height: 170)
-                                .background(.red)
+                                .background(.blue)
                                 .clipShape(RoundedRectangle(cornerRadius: 8.0))
                                 .padding(.horizontal, 2)
                             Text(movie.title)
                                 .font(.headline)
                                 .foregroundStyle(.primary)
                                 .foregroundColor(.primary)
-                        }
+                        }.padding(EdgeInsets(top: 2, leading: 2, bottom: 12, trailing: 2))
                     }
                 }
             }
-        }
+            
+        }.scrollIndicators(.hidden)
     }
 }
 
 #Preview {
-    CarouselView(movies: [Movie(title: "Title", imageUrl: "popcorn.fill"),
-                          Movie(title: "Title", imageUrl: "popcorn.fill"),
-                          Movie(title: "Title", imageUrl: "popcorn.fill")],
-                 headerTitle: "Title", itemTapped: {_,_ in })
+    HorizontalGridView(movies: [Movie(title: "Title", imageUrl: "popcorn.fill"),
+                                Movie(title: "Title", imageUrl: "popcorn.fill"),
+                                Movie(title: "Title", imageUrl: "popcorn.fill")], headerTitle: "Title")
 }

--- a/MovieShowcase/Common/GridView.swift
+++ b/MovieShowcase/Common/GridView.swift
@@ -1,9 +1,3 @@
-//
-//  GridView.swift
-//  MovieShowcase
-//
-//  Created by Vaibhav Limbani on 13/03/25.
-//
 
 import SwiftUI
 

--- a/MovieShowcase/TabView/LandingTabView.swift
+++ b/MovieShowcase/TabView/LandingTabView.swift
@@ -1,9 +1,3 @@
-//
-//  TabView.swift
-//  MovieShowcase
-//
-//  Created by Pratik Parmar on 03/08/24.
-//
 
 import SwiftUI
 

--- a/MovieShowcase/TabView/Tab Items/Home/HomeView.swift
+++ b/MovieShowcase/TabView/Tab Items/Home/HomeView.swift
@@ -19,20 +19,11 @@ struct HomeView: View {
                 if let img = movies.randomElement()?.imageUrl {
                     BannerView(imageName:img, heightRatio: 0.6)
                 }
-                
-                CarouselView(movies: movies.shuffled(), headerTitle: "Trending", itemTapped: {index, movie in
-                    selectedMovie = movie
-                })
-                
-                CarouselView(movies: movies.shuffled(), headerTitle: "Upcoming", itemTapped: {index, movie in
-                    selectedMovie = movie
-                })
-                
-                CarouselView(movies: movies.shuffled(), headerTitle: "Movies", itemTapped: {index, movie in
-                    selectedMovie = movie
-                })
+                HorizontalGridView(movies: movies.shuffled(), headerTitle: "Trending")
+                HorizontalGridView(movies: movies.shuffled(), headerTitle: "Upcoming")
+                HorizontalGridView(movies: movies.shuffled(), headerTitle: "Movies")
             }
-            .ignoresSafeArea(edges: .top)
+            .ignoresSafeArea(edges: [.top, .leading, .trailing])
             .navigationTitle("Home")
         }
     }

--- a/MovieShowcase/TabView/Tab Items/Home/HomeView.swift
+++ b/MovieShowcase/TabView/Tab Items/Home/HomeView.swift
@@ -19,9 +19,9 @@ struct HomeView: View {
                 if let img = movies.randomElement()?.imageUrl {
                     BannerView(imageName:img, heightRatio: 0.6)
                 }
-                HorizontalGridView(movies: movies.shuffled(), headerTitle: "Trending")
-                HorizontalGridView(movies: movies.shuffled(), headerTitle: "Upcoming")
-                HorizontalGridView(movies: movies.shuffled(), headerTitle: "Movies")
+                CarouselView(movies: movies.shuffled(), headerTitle: "Trending")
+                CarouselView(movies: movies.shuffled(), headerTitle: "Upcoming")
+                CarouselView(movies: movies.shuffled(), headerTitle: "Movies")
             }
             .ignoresSafeArea(edges: [.top, .leading, .trailing])
             .navigationTitle("Home")

--- a/MovieShowcase/TabView/Tab Items/Liked/LikedView.swift
+++ b/MovieShowcase/TabView/Tab Items/Liked/LikedView.swift
@@ -1,14 +1,5 @@
-//
-//  LikedView.swift
-//  MovieShowcase
-//
-//  Created by Pratik Parmar on 03/08/24.
-//
 
 import SwiftUI
-
-
-
 
 struct LikedView: View {
     

--- a/MovieShowcase/TabView/Tab Items/Movies/MoviesView.swift
+++ b/MovieShowcase/TabView/Tab Items/Movies/MoviesView.swift
@@ -1,9 +1,3 @@
-//
-//  MoviesView.swift
-//  MovieShowcase
-//
-//  Created by Pratik Parmar on 03/08/24.
-//
 
 import SwiftUI
 

--- a/MovieShowcase/TabView/Tab Items/Series/SeriesView.swift
+++ b/MovieShowcase/TabView/Tab Items/Series/SeriesView.swift
@@ -1,9 +1,3 @@
-//
-//  SeriesView.swift
-//  MovieShowcase
-//
-//  Created by Pratik Parmar on 03/08/24.
-//
 
 import SwiftUI
 


### PR DESCRIPTION
Previously the carousel view was made by horizontal scrollview (which was not an optimal approach) so now I have updated it with builtIn component called **LazyHGridView** to show the carousel throughout the app.

So now HorizontalGridView will be working as a Carousel View across the app.

